### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM kaixhin/cuda-torch
+
+RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
+  libsnappy-dev \
+  graphicsmagick \
+  libgraphicsmagick1-dev \
+  libssl-dev \
+  ca-certificates \
+  git && \
+  rm -rf /var/lib/apt/lists/*
+
+# https://github.com/nagadomi/waifu2x
+RUN \
+  luarocks install graphicsmagick && \
+  luarocks install lua-csnappy && \
+  luarocks install md5 && \
+  luarocks install uuid && \
+  luarocks install csvigo && \
+  PREFIX=$HOME/torch/install luarocks install turbo && \
+  luarocks install cudnn
+
+COPY . /root/waifu2x
+
+WORKDIR /root/waifu2x

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
   git && \
   rm -rf /var/lib/apt/lists/*
 
-# https://github.com/nagadomi/waifu2x
 RUN \
   luarocks install graphicsmagick && \
   luarocks install lua-csnappy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN \
   PREFIX=$HOME/torch/install luarocks install turbo && \
   luarocks install cudnn
 
+# suppress message `tput: No value for $TERM and no -T specified`
+ENV TERM xterm
+
 COPY . /root/waifu2x
 
 WORKDIR /root/waifu2x

--- a/README.md
+++ b/README.md
@@ -261,3 +261,10 @@ docker build -t waifu2x .
 nvidia-docker run -p 8812:8812 waifu2x th web.lua
 nvidia-docker run -v `pwd`/images:/images waifu2x th waifu2x.lua -force_cudnn 1 -m scale -scale 2 -i /images/miku_small.png -o /images/output.png
 ```
+
+Note that running waifu2x in without [JIT caching](https://devblogs.nvidia.com/parallelforall/cuda-pro-tip-understand-fat-binaries-jit-caching/) is very slow, which is what would happen if you use docker.
+For a workaround, you can mount a host volume to the `CUDA_CACHE_PATH`, for instance,
+
+```
+nvidia-docker run -v $PWD/ComputeCache:/root/.nv/ComputeCache waifu2x th waifu2x.lua --help
+```

--- a/README.md
+++ b/README.md
@@ -251,3 +251,13 @@ th train.lua -model upconv_7 -model_dir models/my_model -method noise_scale -sca
 th waifu2x.lua -model_dir models/my_model -m noise_scale -scale 2 -noise_level 1 -i images/miku_small.png -o output.png
 ```
 You can check the performance of model with `models/my_model/noise1_scale2.0x_best.png`.
+
+## Docker
+
+Requires `nvidia-docker`.
+
+```
+docker build -t waifu2x .
+nvidia-docker run -p 8812:8812 waifu2x th web.lua
+nvidia-docker run -v `pwd`/images:/images waifu2x th waifu2x.lua -force_cudnn 1 -m scale -scale 2 -i /images/miku_small.png -o /images/output.png
+```


### PR DESCRIPTION
It works at least, but there is a problem. Starting the program is extremely slow on docker (more than 1 minute).

Once it's started, converting an image is as fast as without docker.

Here is the `strace` output of `th waifu2x.lua --help` in docker. `clock_gettime` seemed a bit slow when I tailed the log.

https://gist.github.com/edvakf/20afca4febd2d7607712c93f4f740878