### PR TITLE
fix Dockerfile: specify version tag for cuda-torch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaixhin/cuda-torch
+FROM kaixhin/cuda-torch:7.5
 
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
   libsnappy-dev \


### PR DESCRIPTION
trying to build image with current Dockerfile gives error `manifest for kaixhin/cuda-torch:latest not found`, since there's no longer a `latest` tag (https://hub.docker.com/r/kaixhin/cuda-torch/tags/)