### PR TITLE
update piapro link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Click to see the slide show.
 waifu2x is inspired by SRCNN [1]. 2D character picture (HatsuneMiku) is licensed under CC BY-NC by piapro [2].
 
 - [1] Chao Dong, Chen Change Loy, Kaiming He, Xiaoou Tang, "Image Super-Resolution Using Deep Convolutional Networks", http://arxiv.org/abs/1501.00092
-- [2] "For Creators", http://piapro.net/en_for_creators.html
-
+- [2] "For Creators", https://piapro.net/intl/en_for_creators.html
 ## Public AMI
 
 TODO


### PR DESCRIPTION
Because they moved their page without setting up a redirect for some reason. I guess CC-BY-NC doesn't require a *working* link, but it surprised me that they made it available with a CC license. You'll probably want to change the URL in the other repo, too.